### PR TITLE
M3508, M2006 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "gm6020_can_cpp"
+name = "rm_motors_can_cpp"
 version = "0.1.0"
 edition = "2021"
 authors = [
     "Matthew Foran <matthewjforan@gmail.com>",
 ]
-repository = "https://github.com/mjforan/gm6020_can"
+repository = "https://github.com/mjforan/rm_motors_can"
 license = "MPL 2.0"
-description = "CAN bus control interface of RoboMaster GM6020 motor, with C++ bindings"
+description = "CAN bus control interface of RoboMaster motors, with C++ bindings"
 
 [dependencies]
-gm6020_can = { path = "gm6020_can" }
+rm_motors_can = { path = "rm_motors_can" }
 
 [build-dependencies]
 cbindgen = "0.26.0"
@@ -22,10 +22,10 @@ ctrlc = "3.4"
 
 
 [lib]
-name = "gm6020_can_cpp"
+name = "rm_motors_can_cpp"
 crate-type = ["staticlib", "cdylib", "lib"]
 
 
 [[example]]
-name = "gm6020_can_test_cpp"
+name = "rm_motors_can_test_cpp"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# `gm6020_can`
-This Rust library controls a DJI GM6020 motor over a Linux SocketCAN interface.
+# `rm_motors_can`
+This Rust library controls a DJI RoboMaster motors over a Linux SocketCAN interface.
 
-<img src="gm6020_can_test_cpp.gif" alt="gm6020_can_test_cpp"  loop=infinite>
+<img src="rm_motors_can_test_cpp.gif" alt="rm_motors_can_test_cpp"  loop=infinite>
+
+TODO update table with specs for other motors (currently just GM6020)
 
 <table>
 <tr><td>
@@ -33,18 +35,18 @@ Switching from Voltage/Velocity to Current/Torque modes requires changing parame
 Temperature is only reported in whole-number precision.
 
 
-# `gm6020_can_cpp`
-This library provides a C/C++ wrapper over `gm6020_can`. Static and dynamic libraries are created in the target directory and header files are generated in the include directory. A neat way to include this in your C++ program is to use Corrosion, which will automatically build the Rust crate and create a CMake target to link against.
+# `rm_motors_can_cpp`
+This library provides a C/C++ wrapper over `rm_motors_can`. Static and dynamic libraries are created in the target directory and header files are generated in the include directory. A neat way to include this in your C++ program is to use Corrosion, which will automatically build the Rust crate and create a CMake target to link against.
 
-Unfortunately the C header does not contain "fully-qualified" names. Ideally each name would be prefixed with `gm6020_can_` to avoid conflict of common names like `init`. There is some ongoing work in the `cbindgen` tool to address this. If it is an issue for your project, change the function names in Rust and uncomment the `[export]` block in [`cbindgen_c.toml`](cbindgen_c.toml) to prefix all other items.
+Unfortunately the C header does not contain "fully-qualified" names. Ideally each name would be prefixed with `rm_motors_can_` to avoid conflict of common names like `init`. There is some ongoing work in the `cbindgen` tool to address this. If it is an issue for your project, change the function names in Rust and uncomment the `[export]` block in [`cbindgen_c.toml`](cbindgen_c.toml) to prefix all other items.
 
 
-# [`gm6020_ros`](https://github.com/mjforan/gm6020_ros/)
+# [`rm_motors_ros`](https://github.com/mjforan/rm_motors_ros/)
 ROS 2 wrapper which enables advanced control interfaces such as `ros2_control` and `MoveIt`. Talk about layers of abstraction! This repo has an example hardware setup and `CMakeLists.txt`.
 
 
 # Hardware
-The GM6020 motor should be accessible via a SocketCAN interface. This can be accomplished with a USB CAN adapter, Raspberry Pi HAT, or built-in CAN interface like on an NVIDIA Orin. Don't forget to power the motor with 24V, configure CAN termination resistors, and set the motor ID; from the factory the ID is 0, which is invalid.
+The motor should be accessible via a SocketCAN interface. This can be accomplished with a USB CAN adapter, Raspberry Pi HAT, or built-in CAN interface like on an NVIDIA Orin. Don't forget to power the motor with 24V, configure CAN termination resistors, and set the motor ID; from the factory the ID is 0, which is invalid for GM6020.
 
 
 # Build
@@ -59,15 +61,15 @@ cargo build --release
 By default the examples connect to a motor on `can0` with ID `1`. They command the motor in `voltage` mode and display `velocity` values.
 These choices are set as constants at the top of the examples and may need to be changed to work with your system.
 
-### [Rust example](gm6020_can/examples/gm6020_can_test.rs)
+### [Rust example](rm_motors_can/examples/rm_motors_can_test.rs)
 ```
-cd gm6020_can
-cargo run --release --example gm6020_can_test
+cd rm_motors_can
+cargo run --release --example rm_motors_can_test
 ```
 
-### [C++ example](examples/gm6020_can_test_cpp.rs)
+### [C++ example](examples/rm_motors_can_test_cpp.rs)
 ```
-cargo run --release --example gm6020_can_test_cpp
+cargo run --release --example rm_motors_can_test_cpp
 ```
 
 

--- a/build.rs
+++ b/build.rs
@@ -5,8 +5,8 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-  println!("cargo:rerun-if-changed=include/gm6020_can.h");
-  println!("cargo:rerun-if-changed=include/gm6020_can.hpp");
+  println!("cargo:rerun-if-changed=include/rm_motors_can.h");
+  println!("cargo:rerun-if-changed=include/rm_motors_can.hpp");
 
   // Don't do any custom build steps if this is being run by our manual invocation of `cargo expand` (avoid infinite recursion)
   if env::var("CARGO_EXPAND").is_ok() {
@@ -38,7 +38,7 @@ fn main() {
     .with_config(config_c)
     .generate()
     .expect("Failed to generate C header")
-    .write_to_file("include/gm6020_can.h");
+    .write_to_file("include/rm_motors_can.h");
 
   cbindgen::Builder::new()
     .with_src((&crate_dir).join("src/expanded.rs"))
@@ -46,19 +46,19 @@ fn main() {
     .with_config(config_cpp)
     .generate()
     .expect("Failed to generate C++ header")
-    .write_to_file("include/gm6020_can.hpp");
+    .write_to_file("include/rm_motors_can.hpp");
 
 
   // TODO bug in cc where it is unable to link to system libraries for an example in a lib crate  https://github.com/rust-lang/cc-rs/issues/1206
   // Compile the C++ example
   // There is no good way to do this conditionally i.e. only when `cargo build --examples`
 
-  println!("cargo:rerun-if-changed=examples/gm6020_can_test.cpp");
+  println!("cargo:rerun-if-changed=examples/rm_motors_can_test.cpp");
   cc::Build::new()
   .cpp(true)
-  .file("examples/gm6020_can_test.cpp")
+  .file("examples/rm_motors_can_test.cpp")
   .cpp_link_stdlib("stdc++")
-  .compile("gm6020_can_test_cpp");
+  .compile("rm_motors_can_test_cpp");
 
   fs::remove_file("src/expanded.rs").expect("Unable to delete expanded lib.rs"); // Remove the temporary file
 }

--- a/cbindgen_c.toml
+++ b/cbindgen_c.toml
@@ -1,16 +1,16 @@
 language = "C"
-include_guard = "GM6020_CAN_H"
+include_guard = "RM_MOTORS_CAN_H"
 
 #[export]
-#prefix="gm6020_can_"
+#prefix="rm_motors_can_"
 
 [parse]
 # generate bindings for dependencies
 parse_deps = true
 # but actually only this crate and the one dependency
-include = ["gm6020_can_cpp", "gm6020_can"]
+include = ["rm_motors_can_cpp", "rm_motors_can"]
 # and yes, I really do mean this one
-extra_bindings = ["gm6020_can"]
+extra_bindings = ["rm_motors_can"]
 # force cbindgen to expand macros (which generate the wrapper functions) before creating a header file.
 # this doesn't work, do manually in build.rs instead
-#expand = ["gm6020_can_cpp"]
+#expand = ["rm_motors_can_cpp"]

--- a/cbindgen_cpp.toml
+++ b/cbindgen_cpp.toml
@@ -1,14 +1,14 @@
 language = "C++"
-namespace = "gm6020_can"
-include_guard = "GM6020_CAN_HPP"
+namespace = "rm_motors_can"
+include_guard = "RM_MOTORS_CAN_HPP"
 
 [parse]
 # generate bindings for dependencies
 parse_deps = true
 # but actually only this crate and the one dependency
-include = ["gm6020_can_cpp", "gm6020_can"]
+include = ["rm_motors_can_cpp", "rm_motors_can"]
 # and yes, I really do mean this one
-extra_bindings = ["gm6020_can"]
+extra_bindings = ["rm_motors_can"]
 # force cbindgen to expand macros (which generate the wrapper functions) before creating a header file.
 # this doesn't work, do manually in build.rs instead
-#expand = ["gm6020_can_cpp"]
+#expand = ["rm_motors_can_cpp"]

--- a/examples/rm_motors_can_test.cpp
+++ b/examples/rm_motors_can_test.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include "../include/gm6020_can.hpp"
+#include "../include/rm_motors_can.hpp"
 #include <stdio.h>
 #include <thread>
 #include <chrono>
@@ -13,14 +13,14 @@
 #include <vector>
 
 //////
-// Basic C++ example showing how to use gm6020_can library. Corresponds to gm6020_can/examples/gm6020_can_test.rs
+// Basic C++ example showing how to use rm_motors_can library. Corresponds to rm_motors_can/examples/rm_motors_can_test.rs
 //////
-// cargo run --example gm6020_can_test_cpp
+// cargo run --example rm_motors_can_test_cpp
 
 const unsigned int INC = 10;                                         // Time (ms) between commands in the for loops
-const int MAX = gm6020_can::V_MAX * 10;                              // Need the 10x multiplier so we can easily increment in for loops (can't increment floats).
+const int MAX = rm_motors_can::V_MAX * 10;                              // Need the 10x multiplier so we can easily increment in for loops (can't increment floats).
 const int ID = 1;                                                    // Motor ID [1,7]
-const gm6020_can::FbField FB_FIELD = gm6020_can::FbField::Velocity;  // The feedback value to visualize
+const rm_motors_can::FbField FB_FIELD = rm_motors_can::FbField::Velocity;  // The feedback value to visualize
 const char* CAN_INTERFACE = "can0";                                  // SocketCAN interface to open
 
 // To match the Rust example we would use something like this:
@@ -28,18 +28,18 @@ const char* CAN_INTERFACE = "can0";                                  // SocketCA
 // but in C++ it is not possible to pass additional variables to the signal handler so we must use global variables.
 std::atomic_bool shared_stop = false;
 std::atomic_bool shared_final = false;
-gm6020_can::Gm6020Can* gmc = nullptr;
-void print_output(gm6020_can::Gm6020Can* gm6020_can);
+rm_motors_can::RmMotorsCan* gmc = nullptr;
+void print_output(rm_motors_can::RmMotorsCan* rm_motors_can);
 
-extern "C" int gm6020_can_test_cpp() {
+extern "C" int rm_motors_can_test_cpp() {
     // Open SocketCAN device
-    gmc = gm6020_can::init_bus(CAN_INTERFACE);
+    gmc = rm_motors_can::init_bus(CAN_INTERFACE);
     if (gmc == nullptr){
         std::cerr<<"Error in initialization"<<std::endl;
         return -1;
     }
     // Set up the motor
-    if (gm6020_can::init_motor(gmc, ID, gm6020_can::MotorType::GM6020, gm6020_can::CmdMode::Voltage)<0){
+    if (rm_motors_can::init_motor(gmc, ID, rm_motors_can::MotorType::GM6020, rm_motors_can::CmdMode::Voltage)<0){
         std::cerr<<"Error initializing motor "<<ID<<std::endl;
         return -1;
     }
@@ -58,7 +58,7 @@ extern "C" int gm6020_can_test_cpp() {
         // stop the other threads
         shared_stop.store(true);
         // gently turn off the motors
-        gm6020_can::cleanup(gmc, 5);
+        rm_motors_can::cleanup(gmc, 5);
         // stop this thread
         shared_final.store(true);
     });
@@ -69,7 +69,7 @@ extern "C" int gm6020_can_test_cpp() {
     // running consistently, which prevents the socket buffer from filling up in case e.g. the main thread is blocked.
     threads.emplace_back(std::thread([](){
         while (!shared_stop.load()) {
-            gm6020_can::run_once(gmc);
+            rm_motors_can::run_once(gmc);
             std::this_thread::sleep_for(std::chrono::milliseconds(INC));
         }
     }));
@@ -77,27 +77,27 @@ extern "C" int gm6020_can_test_cpp() {
     // Ramp up, ramp down, ramp up (negative), ramp down (negative)
     for (int voltage = 0; voltage <= MAX; voltage += 2) {
         if (shared_stop.load()) break; // Check if the ctl-c handler was called
-        gm6020_can::set_cmd(gmc, ID, voltage / 10.0);
+        rm_motors_can::set_cmd(gmc, ID, voltage / 10.0);
         std::this_thread::sleep_for (std::chrono::milliseconds(INC));
     }
     for (int voltage = MAX; voltage > 0; voltage -= 2) {
         if (shared_stop.load()) break; // Check if the ctl-c handler was called
-        gm6020_can::set_cmd(gmc, ID, voltage / 10.0);
+        rm_motors_can::set_cmd(gmc, ID, voltage / 10.0);
         std::this_thread::sleep_for (std::chrono::milliseconds(INC));
     }
     for (int voltage = 0; voltage >= -1*MAX; voltage -=2) {
         if (shared_stop.load()) break; // Check if the ctl-c handler was called
-        gm6020_can::set_cmd(gmc, ID, voltage / 10.0);
+        rm_motors_can::set_cmd(gmc, ID, voltage / 10.0);
         std::this_thread::sleep_for (std::chrono::milliseconds(INC));
     }
     for (int voltage = -1*MAX+1; voltage < 1; voltage += 2) {
         if (shared_stop.load()) break; // Check if the ctl-c handler was called
-        gm6020_can::set_cmd(gmc, ID, voltage / 10.0);
+        rm_motors_can::set_cmd(gmc, ID, voltage / 10.0);
         std::this_thread::sleep_for (std::chrono::milliseconds(INC));
     }
 
     // Send one last voltage command
-    gm6020_can::set_cmd(gmc, ID, 2.0);
+    rm_motors_can::set_cmd(gmc, ID, 2.0);
     // Wait for the ctl-c handler to finish cleaning up
     while (! shared_final.load()){
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -111,22 +111,22 @@ extern "C" int gm6020_can_test_cpp() {
 }
 
 // Print out a simple bar chart of feedback values
-void print_output(gm6020_can::Gm6020Can* gm6020_can) {
-    double val = gm6020_can::get_state(gm6020_can, ID, FB_FIELD);
+void print_output(rm_motors_can::RmMotorsCan* rm_motors_can) {
+    double val = rm_motors_can::get_state(rm_motors_can, ID, FB_FIELD);
      // Right justify, 7 wide, 2 decimal digits
     std::cout<<std::fixed<<std::setprecision(2)<<std::right<<std::setw(7)<<val<<std::left<<std::setw(0)<<"\t";
     unsigned int n = 0;
     switch (FB_FIELD) {
-        case gm6020_can::FbField::Position:
+        case rm_motors_can::FbField::Position:
             n = val*5.0;
             break;
-        case gm6020_can::FbField::Velocity:
+        case rm_motors_can::FbField::Velocity:
             n = abs(val);
             break;
-        case gm6020_can::FbField::Current:
+        case rm_motors_can::FbField::Current:
             n = abs(val*10.0);
             break;
-        case gm6020_can::FbField::Temperature:
+        case rm_motors_can::FbField::Temperature:
             n = val;
             break;
     }

--- a/examples/rm_motors_can_test_cpp.rs
+++ b/examples/rm_motors_can_test_cpp.rs
@@ -1,4 +1,4 @@
 // TODO ideally we would call test_cpp() here directly, but there is a bug in the cc crate where we have to do it from the library
 fn main() {
-    unsafe {gm6020_can_cpp::cpp_example()};
+    unsafe {rm_motors_can_cpp::cpp_example()};
 }

--- a/gm6020_can/src/lib.rs
+++ b/gm6020_can/src/lib.rs
@@ -7,24 +7,55 @@ use std::time::SystemTime;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 
-const FB_ID_BASE: u16 = 0x204;
-const CMD_ID_V_L: u16 = 0x1ff;
-const CMD_ID_V_H: u16 = 0x2ff;
-const CMD_ID_I_L: u16 = 0x1fe;
-const CMD_ID_I_H: u16 = 0x2fe;
+const FB_ID_BASE_6020: u16 = 0x204;
+const FB_ID_BASE_3508: u16 = 0x200;
+const CMD_ID_V_L_6020: u16 = 0x1ff;
+const CMD_ID_V_H_6020: u16 = 0x2ff;
+const CMD_ID_I_L_6020: u16 = 0x1fe;
+const CMD_ID_I_H_6020: u16 = 0x2fe;
+const CMD_ID_I_L_3508: u16 = 0x200;
+const CMD_ID_I_H_3508: u16 = CMD_ID_V_L_6020;
+const CMD_ID_I_L_2006: u16 = CMD_ID_I_L_3508;
+const CMD_ID_I_H_2006: u16 = CMD_ID_I_H_3508;
+
+
 pub const ID_MIN: u8 = 1;
 pub const ID_MAX: u8 = 7;
 const POS_MAX   : u16 = 8191;
-
 pub const RPM_PER_ANGULAR : f64 = 60.0/(2.0*3.14159);
-pub const RPM_PER_V : f64 =  13.33;
-pub const NM_PER_A  : f64 =   0.741;
-pub const V_MAX     : f64 =  24.0;  // Volts DC
-pub const I_MAX     : f64 =   1.62; // Amps ("torque current")
-pub const TEMP_MAX  : u8  = 125;    // C
-const V_CMD_MAX : f64 = 25000.0;    // V_MAX maps to V_CMD_MAX in the CAN messages
-const I_CMD_MAX : f64 = 16384.0;    // I_MAX maps to I_CMD_MAX in the CAN messages
-
+pub fn rpm_per_v(motor_type: MotorType) -> f64 {
+    match motor_type {
+        MotorType::GM6020 => 13.33,
+        MotorType::M3508  => 17.71,
+        MotorType::M2006  =>  3.13,
+    }
+}
+// Amps ("torque current")
+pub fn i_max(motor_type: MotorType) -> f64{
+    match motor_type {
+        MotorType::GM6020 => 1.62,
+        MotorType::M3508  => 20.0,
+        MotorType::M2006  => 10.0,
+    }
+}
+pub fn nm_per_a(motor_type: MotorType) -> f64 {
+    match motor_type {
+        MotorType::GM6020 => 0.741,
+        MotorType::M3508  => 0.353, // approximated from datasheet graph
+        MotorType::M2006  => 0.338, // approximated from datasheet graph
+    }
+}
+pub const V_MAX      : f64 =  24.0;  // Volts DC
+pub const TEMP_MAX   : u8  = 125;    // C
+const V_CMD_MAX: f64 = 25000.0;     // V_MAX maps to V_CMD_MAX in the CAN messages
+// I_MAX maps to I_CMD_MAX in the CAN messages
+pub fn i_cmd_max(motor_type: MotorType) -> f64 {
+    match motor_type {
+        MotorType::GM6020 => 16384.0,
+        MotorType::M3508  => 16384.0,
+        MotorType::M2006  => 10000.0,
+    }
+}
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
@@ -46,9 +77,37 @@ impl fmt::Display for CmdMode {
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
+pub enum MotorType { GM6020, M3508, M2006}
+impl Default for MotorType {
+    fn default() -> Self { MotorType::GM6020 }
+}
+impl fmt::Display for MotorType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MotorType::GM6020 => write!(f, "GM6020"),
+            MotorType::M3508  => write!(f, "M3508"),
+            MotorType::M2006  => write!(f, "M2006"),
+
+        }
+    }
+}
+
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
 pub enum FbField { Position, Velocity, Current, Temperature }
 impl Default for FbField {
     fn default() -> Self { FbField::Position }
+}
+impl fmt::Display for FbField {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FbField::Position     => write!(f, "Position"),
+            FbField::Velocity     => write!(f, "Velocity"),
+            FbField::Current      => write!(f, "Current"),
+            FbField::Temperature  => write!(f, "Temperature"),
+        }
+    }
 }
 
 #[derive(Default, Debug)]
@@ -64,9 +123,11 @@ const ARR_LEN: usize = 8; // (ID_MAX-ID_MIN+1) as usize   only 7 slots will be u
 #[repr(C)]
 pub struct Gm6020Can {
     socket: Mutex<Option<CanSocket>>,
-    modes    : RwLock<[CmdMode; ARR_LEN]>,
-    commands : RwLock<[i16; ARR_LEN]>,
-    feedbacks: RwLock<[(Option<SystemTime>, Feedback); ARR_LEN]>,
+    motor_types : RwLock<[MotorType; ARR_LEN]>,
+    modes       : RwLock<[CmdMode; ARR_LEN]>,
+    commands    : RwLock<[i16; ARR_LEN]>,
+    feedbacks   : RwLock<[(Option<SystemTime>, Feedback); ARR_LEN]>,
+    upper_3508  : RwLock<bool>, // if true, parse CAN ID range 0x205-0x208 as m3508/m2006
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -86,7 +147,7 @@ impl IdRange {
 }
 
 
-pub fn init(interface: &str) -> Result<Arc<Gm6020Can>, String> {
+pub fn init_bus(interface: &str) -> Result<Arc<Gm6020Can>, String> {
     let gm6020_can: Arc<Gm6020Can> = Arc::new(Gm6020Can::default());                      // Arc (Atomically Reference Counted) is like shared_ptr in C++
     let socket: CanSocket = CanSocket::open(&interface).map_err(|err| err.to_string())?;  // Attempt to open the given interface
 
@@ -99,14 +160,14 @@ pub fn init(interface: &str) -> Result<Arc<Gm6020Can>, String> {
             Ok(CanFrame::Error(_)) => (),
             Ok(CanFrame::Data(frame)) => {
                 let frame_id: u16 = frame.raw_id() as u16;
-                if frame_id == CMD_ID_V_L || frame_id == CMD_ID_V_H || frame_id == CMD_ID_I_L || frame_id == CMD_ID_I_H {
+                if frame_id == CMD_ID_V_L_6020 || frame_id == CMD_ID_V_H_6020 || frame_id == CMD_ID_I_L_6020 || frame_id == CMD_ID_I_H_6020 || frame_id == CMD_ID_I_L_3508 || frame_id == CMD_ID_I_H_3508 {
                     return Err(String::from("Another program is sending GM6020 commands already"));
                 }
             },
         };
     }
 
-    let filter: CanFilter = CanFilter::new(FB_ID_BASE as u32, 0xffff - 0xf);  // Create a filter to only accept messages with IDs from 0x200 to 0x20F (Motor feedbacks are 0x205 to 0x20B)
+    let filter: CanFilter = CanFilter::new(FB_ID_BASE_3508 as u32, 0xffff - 0xf);  // Create a filter to only accept messages with IDs from 0x200 to 0x20F (Motor feedbacks are 0x201 to 0x20B)
     socket.set_filters(&[filter]).map_err(|err| err.to_string())?;            // Apply the filter to our interface
     *gm6020_can.socket.lock().unwrap() = Some(socket);                        // Attach the socket to the gm6020_can object for future reading and writing
 
@@ -117,6 +178,42 @@ pub fn init(interface: &str) -> Result<Arc<Gm6020Can>, String> {
     return Ok(gm6020_can);
 }
 
+pub fn init_motor(gm6020_can: Arc<Gm6020Can>, id: u8, motor_type: MotorType, mode: CmdMode) -> Result<i32, String> {
+    if (motor_type == MotorType::M3508 || motor_type == MotorType::M2006) && (mode == CmdMode::Voltage || mode == CmdMode::Velocity){
+        return Err(format!("Attempting to initialize motor {} in {} mode, but it is an {} which only accepts Current or Torque commands", id, mode, motor_type));
+    }
+    let idx: usize = (id-1) as usize;
+    // Check for ID collisions - this is a limitation of DJI's address scheme
+    for i in 0 .. ARR_LEN {
+        if i == idx {continue;}
+        if ( motor_type == MotorType::GM6020 && id < 5  && gm6020_can.modes.read().unwrap()[i] != CmdMode::Disabled && gm6020_can.motor_types.read().unwrap()[i] == MotorType::M3508 ) ||
+           ( (motor_type == MotorType::M3508 || motor_type == MotorType::M2006) && id > 4  && gm6020_can.modes.read().unwrap()[i] != CmdMode::Disabled && gm6020_can.motor_types.read().unwrap()[i] == MotorType::GM6020 ){
+            return Err(format!("GM6020 ID 1-4 cannot coexist with {} ID 5-8", motor_type));
+        }
+    }
+
+    if (motor_type == MotorType::M3508 || motor_type == MotorType::M2006) && id > 4 {
+        *gm6020_can.upper_3508.write().unwrap() = true;
+    }
+
+    let type_actual: MotorType = gm6020_can.motor_types.read().unwrap()[idx];
+    let mode_actual: CmdMode = gm6020_can.modes.read().unwrap()[idx];
+    if mode_actual == CmdMode::Disabled {
+        println!("Initializing {}:{} in {} mode", motor_type, id, mode);
+    }
+    // A motor's mode shouldn't change at runtime because it requires setting a parameter in RoboMaster Assistant
+    else{
+        if mode_actual != mode {
+            eprintln!("Warning: Changing {}:{} from {} to {} mode", motor_type, id, mode_actual, mode);
+        }
+        if type_actual != motor_type {
+            eprintln!("Warning: Changing motor {} from {} to {} type", id, type_actual, motor_type);
+        }
+    }
+    gm6020_can.motor_types.write().unwrap()[idx] = motor_type;
+    gm6020_can.modes.write().unwrap()[idx] = mode;
+    return Ok(0);
+}
 
 /*
 **  Clean up pointers and release the socket
@@ -132,23 +229,25 @@ pub fn cleanup(gm6020_can: Arc<Gm6020Can>, period_ms: u64) -> Result<i32, String
         let gmc: Arc<Gm6020Can> = gm6020_can.clone();
         // Multi-thread so all motors spin down at once
         threads.push(thread::spawn( move ||{
+            let motor_type: MotorType = gmc.motor_types.read().unwrap()[i];
+
             // Avoid get_state - simplify by using only voltage and current commands
             let mut cmd: f64 = match m {
                 CmdMode::Voltage  => gmc.commands.read().unwrap()[i] as f64 /V_CMD_MAX*V_MAX,
                 CmdMode::Velocity => gmc.commands.read().unwrap()[i] as f64 /V_CMD_MAX*V_MAX,
-                CmdMode::Current  => gmc.commands.read().unwrap()[i] as f64 /I_CMD_MAX*I_MAX,
-                CmdMode::Torque   => gmc.commands.read().unwrap()[i] as f64 /I_CMD_MAX*I_MAX,
+                CmdMode::Current  => gmc.commands.read().unwrap()[i] as f64 /i_cmd_max(motor_type)*i_max(motor_type),
+                CmdMode::Torque   => gmc.commands.read().unwrap()[i] as f64 /i_cmd_max(motor_type)*i_max(motor_type),
                 CmdMode::Disabled => panic!("Attempting to clean up disabled motor"),
             };
             let sign: f64 = cmd/cmd.abs();
             loop{
                 if cmd.abs() <= 0.2 || period_ms == 0 {
-                    set_cmd(gmc.clone(), i as u8+ID_MIN, m, 0f64).map_or_else(|e| eprintln!("{}", e), |_| ());
+                    set_cmd(gmc.clone(), i as u8+ID_MIN, 0f64).map_or_else(|e| eprintln!("{}", e), |_| ());
                     run_once(gmc.clone()).map_or_else(|e| eprintln!("{}", e), |_| ());
                     break;
                 }
                 cmd = cmd-sign*0.2;
-                set_cmd(gmc.clone(), i as u8+ID_MIN, m, cmd).map_or_else(|e| eprintln!("{}", e), |_| ());
+                set_cmd(gmc.clone(), i as u8+ID_MIN, cmd).map_or_else(|e| eprintln!("{}", e), |_| ());
                 run_once(gmc.clone()).map_or_else(|e| eprintln!("{}", e), |_| ());
                 thread::sleep(std::time::Duration::from_millis(period_ms));                
             }
@@ -167,62 +266,62 @@ pub fn run_once(gm6020_can: Arc<Gm6020Can>) -> Result<i32, String>{
     rx_fb(gm6020_can.clone())?;
 
     // Loop through all motors and check which combinations of IdRange and CmdMode actually need to be sent
-    let mut i_l: bool = false;
-    let mut i_h: bool = false;
-    let mut v_l: bool = false;
-    let mut v_h: bool = false;
-    for i in 0 .. ARR_LEN {
-        match (gm6020_can.modes.read().unwrap()[i], IdRange::from_u8(i as u8 + ID_MIN)) {
-            (CmdMode::Voltage, IdRange::Low ) => v_l = true,
-            (CmdMode::Voltage, IdRange::High) => v_h = true,
-            (CmdMode::Current, IdRange::Low ) => i_l = true,
-            (CmdMode::Current, IdRange::High) => i_h = true,
-            (_, _) => (),
-        };
-    }
-    // Send the commands, accumulating the results to return
     let mut r: Result<i32, String> = Ok(0);
-    if v_l {r = r.and_then(|_| tx_cmd(gm6020_can.clone(), IdRange::Low,  CmdMode::Voltage));}
-    if v_h {r = r.and_then(|_| tx_cmd(gm6020_can.clone(), IdRange::High, CmdMode::Voltage));}
-    if i_l {r = r.and_then(|_| tx_cmd(gm6020_can.clone(), IdRange::Low,  CmdMode::Current));}
-    if i_h {r = r.and_then(|_| tx_cmd(gm6020_can.clone(), IdRange::High, CmdMode::Current));}
+    for i in 0 .. ARR_LEN {
+        let mode: CmdMode = match gm6020_can.modes.read().unwrap()[i] {
+            CmdMode::Current  => CmdMode::Current,
+            CmdMode::Torque   => CmdMode::Current,
+            CmdMode::Voltage  => CmdMode::Voltage,
+            CmdMode::Velocity => CmdMode::Voltage,
+            CmdMode::Disabled => CmdMode::Disabled,
+        };
+        r = r.and_then(
+            |_| match (mode, IdRange::from_u8(i as u8 + ID_MIN), gm6020_can.motor_types.read().unwrap()[i]) {
+                (CmdMode::Voltage, IdRange::Low , MotorType::GM6020) => tx_cmd(gm6020_can.clone(), CMD_ID_V_L_6020, IdRange::Low),
+                (CmdMode::Voltage, IdRange::High, MotorType::GM6020) => tx_cmd(gm6020_can.clone(), CMD_ID_V_H_6020, IdRange::High),
+                (CmdMode::Current, IdRange::Low , MotorType::GM6020) => tx_cmd(gm6020_can.clone(), CMD_ID_I_L_6020, IdRange::Low),
+                (CmdMode::Current, IdRange::Low , MotorType::M3508 ) => tx_cmd(gm6020_can.clone(), CMD_ID_I_L_3508, IdRange::Low),
+                (CmdMode::Current, IdRange::Low , MotorType::M2006 ) => tx_cmd(gm6020_can.clone(), CMD_ID_I_L_2006, IdRange::Low),
+                (CmdMode::Current, IdRange::High, MotorType::GM6020) => tx_cmd(gm6020_can.clone(), CMD_ID_I_H_6020, IdRange::High),
+                (CmdMode::Current, IdRange::High, MotorType::M3508 ) => tx_cmd(gm6020_can.clone(), CMD_ID_I_H_3508, IdRange::High),
+                (CmdMode::Current, IdRange::High, MotorType::M2006 ) => tx_cmd(gm6020_can.clone(), CMD_ID_I_H_2006, IdRange::High),
+                (_, _, _) => Err(format!("Unknown combination of CmdMode, IdRange, MotorType in run_once")),
+            }
+        );
+    };
+    // Send the commands, accumulating the results to return
     return r;
 }
 
 
-pub fn set_cmd(gm6020_can: Arc<Gm6020Can>, id: u8, mode: CmdMode, cmd: f64) -> Result<i32, String> {
+pub fn set_cmd(gm6020_can: Arc<Gm6020Can>, id: u8, cmd: f64) -> Result<i32, String> {
     // Check id range and convert to array index
     if id<ID_MIN || id>ID_MAX { return Err(format!("id out of range [{}, {}]: {}", ID_MIN, ID_MAX, id)); }
-    let idx = (id-1) as usize;
+    let idx: usize = (id-1) as usize;
     // If the motor is too hot, write 0 command and return error
+    // TODO what to do about m3508, m2006?
     if gm6020_can.feedbacks.read().unwrap()[idx].1.temperature >= TEMP_MAX as u16 { gm6020_can.commands.write().unwrap()[idx] = 0; return Err(format!("temperature overload [{}]: {}", TEMP_MAX, gm6020_can.feedbacks.read().unwrap()[idx].1.temperature));}
+    let mode: CmdMode = gm6020_can.modes.read().unwrap()[idx];
+    let motor_type: MotorType = gm6020_can.motor_types.read().unwrap()[idx];
+    let mut cmd_actual: f64 = cmd;
     // Convert torque and velocity commands to corresponding current and voltage commands
-    if mode == CmdMode::Torque   {return set_cmd(gm6020_can, id, CmdMode::Current, cmd/NM_PER_A);}
-    if mode == CmdMode::Velocity {return set_cmd(gm6020_can, id, CmdMode::Voltage, cmd*RPM_PER_ANGULAR/RPM_PER_V);}
+    if mode == CmdMode::Torque   {cmd_actual/=nm_per_a(motor_type);}
+    if mode == CmdMode::Velocity {cmd_actual*=RPM_PER_ANGULAR/rpm_per_v(motor_type);}
     // Limit to max allowable command values
-    if mode == CmdMode::Voltage && cmd.abs() > V_MAX {
+    if (mode == CmdMode::Voltage || mode == CmdMode::Velocity) && cmd_actual.abs() > V_MAX {
         eprintln!("Warning: voltage out of range [{}, {}]: {}. Clamping.", -1.0*V_MAX, V_MAX, cmd);
-        return set_cmd(gm6020_can, id, CmdMode::Voltage, V_MAX*cmd.abs()/cmd);
+        cmd_actual = V_MAX*cmd.abs()/cmd;
     }
-    if mode == CmdMode::Current && cmd.abs() > I_MAX {
-        eprintln!("Warning: current out of range [{}, {}]: {}. Clamping.", -1.0*I_MAX, I_MAX, cmd);
-        return set_cmd(gm6020_can, id, CmdMode::Current, I_MAX*cmd.abs()/cmd);
-    }
-    // A motor's mode shouldn't change at runtime because it requires setting a parameter in RoboMaster Assistant
-    let mode_actual: CmdMode = gm6020_can.modes.read().unwrap()[idx];
-    if mode_actual == CmdMode::Disabled {
-        println!("Setting motor {} to {} mode", id, mode);
-        gm6020_can.modes.write().unwrap()[idx] = mode;
-    }
-    else if mode_actual != mode {
-        eprintln!("Warning: Changing motor {} from {} to {} mode", id, mode_actual, mode);
-        gm6020_can.modes.write().unwrap()[idx] = mode;
+    let i_max: f64 = i_max(motor_type);
+
+    if (mode == CmdMode::Current || mode == CmdMode::Torque) && cmd_actual.abs() > i_max {
+        eprintln!("Warning: current out of range [{}, {}]: {}. Clamping.", -1.0*i_max, i_max, cmd);
+        cmd_actual = i_max*cmd.abs()/cmd;
     }
 
-    // Map the volts/amps command to the low-level range expected by the motor
     gm6020_can.commands.write().unwrap()[idx] = match mode {
-        CmdMode::Voltage => (V_CMD_MAX*cmd/V_MAX) as i16,
-        CmdMode::Current => (I_CMD_MAX*cmd/I_MAX) as i16,
+        CmdMode::Voltage => (V_CMD_MAX*cmd_actual/V_MAX) as i16,
+        CmdMode::Current => (i_cmd_max(motor_type)*cmd_actual/i_max) as i16,
         _ => panic!("Invalid mode, logic error in `set_cmd`"),
     };
     Ok(0)
@@ -235,21 +334,12 @@ pub fn set_cmd(gm6020_can: Arc<Gm6020Can>, id: u8, mode: CmdMode, cmd: f64) -> R
 **  id_range: send to low [1,4] or high [5,7] motors
 **  mode: send voltage or current commands
 */
-fn tx_cmd(gm6020_can: Arc<Gm6020Can>, id_range: IdRange, mode: CmdMode) -> Result<i32, String> {
-    // Determine which CAN id to send based on the command mode and id range
-    let id: u16 = match (mode, id_range) {
-        (CmdMode::Voltage, IdRange::Low ) => CMD_ID_V_L,
-        (CmdMode::Voltage, IdRange::High) => CMD_ID_V_H,
-        (CmdMode::Current, IdRange::Low ) => CMD_ID_I_L,
-        (CmdMode::Current, IdRange::High) => CMD_ID_I_H,
-        (_, _) => panic!(),
-    };
-
+fn tx_cmd(gm6020_can: Arc<Gm6020Can>, frame_id: u16, id_range: IdRange) -> Result<i32, String> {
     // Slice half of the commands array, depending on the id range
     let cmds: &[i16] = &gm6020_can.commands.read().unwrap()[((id_range as u8) * 4) as usize .. (4 + (id_range as u8)*4) as usize];
     // Construct a CAN frame using the ID and cmds data
     let frame = CanFrame::new(
-        StandardId::new(id).unwrap(),
+        StandardId::new(frame_id).unwrap(),
         &[(cmds[0]>>8) as u8, cmds[0] as u8, (cmds[1]>>8) as u8, cmds[1] as u8, (cmds[2]>>8) as u8, cmds[2] as u8, (cmds[3]>>8) as u8, cmds[3] as u8])
         .ok_or_else(|| Err::<CanFrame, String>("Failed to open socket".to_string())).unwrap();
     // Write the frame
@@ -283,8 +373,18 @@ fn rx_fb(gm6020_can: Arc<Gm6020Can>) -> Result<i32, String> {
             Ok(CanFrame::Data(frame)) => {
                 // Convert CAN frame ID to motor ID
                 let rxid: u16 = frame.raw_id() as u16;
-                let id: u8 = (rxid-FB_ID_BASE)as u8;
-                if id<ID_MIN || id>ID_MAX {continue;}
+                let id: u8;
+                // M3508 ID range
+                if rxid < 0x204 || (rxid >= 0x204 && rxid <= 0x208 && *gm6020_can.upper_3508.read().unwrap()) {
+                    id = (rxid-FB_ID_BASE_3508) as u8;
+                }
+                // MG6020 ID range
+                else if rxid >= 0x204 && rxid <= 0x20B {
+                    id = (rxid-FB_ID_BASE_6020) as u8;
+                }
+                else {
+                    continue;
+                }
 
                 // Get a reference to the feedback object and data array to simplify the parsing code
                 let f: &mut (Option<SystemTime>, Feedback) = &mut gm6020_can.feedbacks.write().unwrap()[(id-1) as usize];
@@ -303,10 +403,14 @@ fn rx_fb(gm6020_can: Arc<Gm6020Can>) -> Result<i32, String> {
 
 
 pub fn get_state(gm6020_can: Arc<Gm6020Can>, id: u8, field: FbField) -> Result<f64, String>{
+    let motor_type: MotorType = gm6020_can.motor_types.read().unwrap()[(id-1) as usize];
+    if motor_type == MotorType::M2006 && (field == FbField::Current || field == FbField::Temperature){
+        return Err(format!("Motor {} is an M2006, which does not report {}", id, field));
+    }
     Ok(match field {
         FbField::Position    => gm6020_can.feedbacks.read().unwrap()[(id-1)as usize].1.position as f64/POS_MAX as f64 *2f64*PI,
         FbField::Velocity    => gm6020_can.feedbacks.read().unwrap()[(id-1)as usize].1.velocity as f64/RPM_PER_ANGULAR,
-        FbField::Current     => gm6020_can.feedbacks.read().unwrap()[(id-1)as usize].1.current as f64/I_CMD_MAX*I_MAX,
+        FbField::Current     => gm6020_can.feedbacks.read().unwrap()[(id-1)as usize].1.current as f64/i_cmd_max(motor_type)*i_max(motor_type),
         FbField::Temperature => gm6020_can.feedbacks.read().unwrap()[(id-1)as usize].1.temperature as f64,
     })
 }

--- a/gm6020_can/src/lib.rs
+++ b/gm6020_can/src/lib.rs
@@ -31,14 +31,16 @@ pub fn rpm_per_v(motor_type: MotorType) -> f64 {
     }
 }
 // Amps ("torque current")
-pub fn i_max(motor_type: MotorType) -> f64{
+#[no_mangle]
+pub extern "C" fn i_max(motor_type: MotorType) -> f64{
     match motor_type {
         MotorType::GM6020 => 1.62,
         MotorType::M3508  => 20.0,
         MotorType::M2006  => 10.0,
     }
 }
-pub fn nm_per_a(motor_type: MotorType) -> f64 {
+#[no_mangle]
+pub extern "C" fn nm_per_a(motor_type: MotorType) -> f64 {
     match motor_type {
         MotorType::GM6020 => 0.741,
         MotorType::M3508  => 0.353, // approximated from datasheet graph
@@ -49,7 +51,8 @@ pub const V_MAX      : f64 =  24.0;  // Volts DC
 pub const TEMP_MAX   : u8  = 125;    // C
 const V_CMD_MAX: f64 = 25000.0;     // V_MAX maps to V_CMD_MAX in the CAN messages
 // I_MAX maps to I_CMD_MAX in the CAN messages
-pub fn i_cmd_max(motor_type: MotorType) -> f64 {
+#[no_mangle]
+pub extern "C" fn i_cmd_max(motor_type: MotorType) -> f64 {
     match motor_type {
         MotorType::GM6020 => 16384.0,
         MotorType::M3508  => 16384.0,

--- a/rm_motors_can/Cargo.toml
+++ b/rm_motors_can/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "gm6020_can"
+name = "rm_motors_can"
 version = "0.1.0"
 edition = "2021"
 authors = [
     "Matthew Foran <matthewjforan@gmail.com>",
 ]
-repository = "https://github.com/mjforan/gm6020_can"
+repository = "https://github.com/mjforan/rm_motors_can"
 license = "MPL 2.0"
-description = "CAN bus control interface of RoboMaster GM6020 motor"
+description = "CAN bus control interface of RoboMaster motors"
 
 [dependencies]
 embedded-can = "0.4.1"
@@ -17,8 +17,8 @@ socketcan = "3.3.0"
 ctrlc = "3.4"
 
 [lib]
-name = "gm6020_can"
+name = "rm_motors_can"
 crate-type = ["lib"]
 
 [[example]]
-name = "gm6020_can_test"
+name = "rm_motors_can_test"

--- a/rm_motors_can/examples/rm_motors_can_test.rs
+++ b/rm_motors_can/examples/rm_motors_can_test.rs
@@ -1,34 +1,34 @@
-use gm6020_can::{CmdMode, FbField, Gm6020Can, MotorType};
+use rm_motors_can::{CmdMode, FbField, RmMotorsCan, MotorType};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 use std::sync::Arc;
 use ctrlc;
 
 //////
-// Example showing how to use gm6020_can library.
+// Example showing how to use rm_motors_can library.
 //////
 /*
-cargo run --example gm6020_can_test
+cargo run --example rm_motors_can_test
 */
 
 const INC: u64 = 10;                               // Time (ms) between commands in the for loops
-const MAX: i16 = (gm6020_can::V_MAX) as i16 * 10;  // Need the 10x multiplier so we can easily increment in for loops (can't increment floats).
+const MAX: i16 = (rm_motors_can::V_MAX) as i16 * 10;  // Need the 10x multiplier so we can easily increment in for loops (can't increment floats).
 const ID: u8 = 1;                                  // Motor ID [1,7]
 const FB_FIELD: FbField = FbField::Velocity;       // The feedback value to visualize
 const CAN_INTERFACE: &str = "can0";                // SocketCAN interface to open
 
 fn main() {
     // Open SocketCAN device
-    let gmc: Arc<Gm6020Can> = gm6020_can::init_bus(CAN_INTERFACE).unwrap();
+    let gmc: Arc<RmMotorsCan> = rm_motors_can::init_bus(CAN_INTERFACE).unwrap();
     // Set up the motor
-    gm6020_can::init_motor(gmc.clone(), ID, MotorType::GM6020, CmdMode::Voltage).map_or_else(|e| panic!("{}", e), |_| ());
+    rm_motors_can::init_motor(gmc.clone(), ID, MotorType::GM6020, CmdMode::Voltage).map_or_else(|e| panic!("{}", e), |_| ());
 
     // Atomic flag to trigger stopping the threads
     let shared_stop: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
     // Spawn another thread to visualize the feedback values
     let shared_stop_ref2: Arc<AtomicBool> = shared_stop.clone();
-    let gmc_ref2: Arc<Gm6020Can> = gmc.clone();
+    let gmc_ref2: Arc<RmMotorsCan> = gmc.clone();
     let _dbg: JoinHandle<()> = thread::spawn( move ||
         while ! shared_stop_ref2.load(Ordering::Relaxed){
             thread::sleep(std::time::Duration::from_millis(50));
@@ -40,12 +40,12 @@ fn main() {
     let shared_stop_ref3: Arc<AtomicBool> = shared_stop.clone();
     let shared_final: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
     let shared_final_ref2: Arc<AtomicBool> = shared_final.clone();
-    let gmc_ref3: Arc<Gm6020Can> = gmc.clone();
+    let gmc_ref3: Arc<RmMotorsCan> = gmc.clone();
     let _ = ctrlc::set_handler(move || {
         // stop the other threads
         shared_stop_ref3.store(true, Ordering::Relaxed);
         // gently turn off the motors
-        gm6020_can::cleanup(gmc_ref3.clone(), 5).map_or_else(|e| eprintln!("{}", e), |_| ());
+        rm_motors_can::cleanup(gmc_ref3.clone(), 5).map_or_else(|e| eprintln!("{}", e), |_| ());
         // stop this thread
         shared_final_ref2.store(true, Ordering::Relaxed);
     });
@@ -55,10 +55,10 @@ fn main() {
     // but if this loop is fast enough it will not be noticeable. This approach has the advantage of
     // running consistently, which prevents the socket buffer from filling up in case e.g. the main thread is blocked.
     let shared_stop_ref4: Arc<AtomicBool> = shared_stop.clone();
-    let gmc_ref4: Arc<Gm6020Can> = gmc.clone();
+    let gmc_ref4: Arc<RmMotorsCan> = gmc.clone();
     thread::spawn( move ||
         while ! shared_stop_ref4.load(Ordering::Relaxed) {
-            gm6020_can::run_once(gmc_ref4.clone()).map_or_else(|e| eprintln!("{}", e), |_| ());
+            rm_motors_can::run_once(gmc_ref4.clone()).map_or_else(|e| eprintln!("{}", e), |_| ());
             thread::sleep(std::time::Duration::from_millis(INC));
         }
     );
@@ -66,27 +66,27 @@ fn main() {
     // Ramp up, ramp down, ramp up (negative), ramp down (negative)
     for voltage in (0 .. MAX+1).step_by(2) {
         if shared_stop.load(Ordering::Relaxed) {break;} // Check if the ctl-c handler was called
-        gm6020_can::set_cmd(gmc.clone(), ID, voltage as f64 / 10f64).map_or_else(|e| eprintln!("{}", e), |_| ());
+        rm_motors_can::set_cmd(gmc.clone(), ID, voltage as f64 / 10f64).map_or_else(|e| eprintln!("{}", e), |_| ());
         thread::sleep(std::time::Duration::from_millis(INC));
     }
     for voltage in (0 .. MAX).rev().step_by(2) {
         if shared_stop.load(Ordering::Relaxed) {break;} // Check if the ctl-c handler was called
-        gm6020_can::set_cmd(gmc.clone(), ID, voltage as f64 / 10f64).map_or_else(|e| eprintln!("{}", e), |_| ());
+        rm_motors_can::set_cmd(gmc.clone(), ID, voltage as f64 / 10f64).map_or_else(|e| eprintln!("{}", e), |_| ());
         thread::sleep(std::time::Duration::from_millis(INC));
     }
     for voltage in (-1*MAX .. 0).rev().step_by(2) {
         if shared_stop.load(Ordering::Relaxed) {break;} // Check if the ctl-c handler was called
-        gm6020_can::set_cmd(gmc.clone(), ID, voltage as f64 / 10f64).map_or_else(|e| eprintln!("{}", e), |_| ());
+        rm_motors_can::set_cmd(gmc.clone(), ID, voltage as f64 / 10f64).map_or_else(|e| eprintln!("{}", e), |_| ());
         thread::sleep(std::time::Duration::from_millis(INC));
     }
     for voltage in (-1*MAX+1 .. 1).step_by(2) {
         if shared_stop.load(Ordering::Relaxed) {break;} // Check if the ctl-c handler was called
-        gm6020_can::set_cmd(gmc.clone(), ID, voltage as f64 / 10f64).map_or_else(|e| eprintln!("{}", e), |_| ());
+        rm_motors_can::set_cmd(gmc.clone(), ID, voltage as f64 / 10f64).map_or_else(|e| eprintln!("{}", e), |_| ());
         thread::sleep(std::time::Duration::from_millis(INC));
     }
 
     // Send one last voltage command
-    gm6020_can::set_cmd(gmc.clone(), ID, 2f64).map_or_else(|e| eprintln!("{}", e), |_| ());
+    rm_motors_can::set_cmd(gmc.clone(), ID, 2f64).map_or_else(|e| eprintln!("{}", e), |_| ());
     // Wait for the ctl-c handler to finish cleaning up
     while ! shared_final.load(Ordering::Relaxed){
         thread::sleep(std::time::Duration::from_millis(50));
@@ -94,8 +94,8 @@ fn main() {
 }
 
 // Print out a simple bar chart of feedback values
-fn print_output(gm6020_can: Arc<Gm6020Can>) {
-    let val = gm6020_can::get_state(gm6020_can, ID, FB_FIELD).unwrap();
+fn print_output(rm_motors_can: Arc<RmMotorsCan>) {
+    let val = rm_motors_can::get_state(rm_motors_can, ID, FB_FIELD).unwrap();
     print!("{val:>7.2}\t"); // Right justify, 7 wide, 2 decimal digits
     println!("{:#<1$}", "", match FB_FIELD {
         FbField::Position    => (val*5f64) as usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 **  returns: pointer to Gm6020Can struct, to be passed to other functions in this library
 */
 #[no_mangle]
-pub extern "C" fn init(interface: *const c_char) -> *mut Gm6020Can {
+pub extern "C" fn init_bus(interface: *const c_char) -> *mut Gm6020Can {
     let inter: &str;
     if interface.is_null() {
         println!("Invalid c-string received for interface name (null pointer)");
@@ -26,7 +26,7 @@ pub extern "C" fn init(interface: *const c_char) -> *mut Gm6020Can {
             inter = r.unwrap();
         }
     }
-    gm6020_can::init(inter).map_or_else(|e| {eprintln!("{}", e); null::<Gm6020Can>() as *const Gm6020Can}, |v| Arc::into_raw(v)) as *mut Gm6020Can
+    gm6020_can::init_bus(inter).map_or_else(|e| {eprintln!("{}", e); null::<Gm6020Can>() as *const Gm6020Can}, |v| Arc::into_raw(v)) as *mut Gm6020Can
 }
 
 macro_rules! generate_wrapper {
@@ -46,10 +46,11 @@ macro_rules! generate_wrapper {
     };
 }
 
-generate_wrapper!(cleanup,   (period_ms: u64), i32);
-generate_wrapper!(run_once,  (), i32);
-generate_wrapper!(set_cmd,   (id: u8, mode: CmdMode, cmd: f64), i32);
-generate_wrapper!(get_state, (id: u8, field: FbField), f64);
+generate_wrapper!(init_motor, (id: u8, motor_type: MotorType, mode: CmdMode), i32);
+generate_wrapper!(cleanup,    (period_ms: u64), i32);
+generate_wrapper!(run_once,   (), i32);
+generate_wrapper!(set_cmd,    (id: u8, cmd: f64), i32);
+generate_wrapper!(get_state,  (id: u8, field: FbField), f64);
 
 
 #[link(name = "gm6020_can_test_cpp")]


### PR DESCRIPTION
Extended to support additional CAN bus schemes of RoboMaster M3508 and M2006 motors. API changes include setting motor type and requiring separate `init_bus` and `init_motor` methods. Also, several constants have become functions which return a different constant depending on motor type. M3508 and M2006 compatibility are untested due to lack of hardware, but this should be okay to merge because GM6020 functionality has not regressed.